### PR TITLE
Update Vulnerability_Disclosure_Cheat_Sheet_ja.md

### DIFF
--- a/skillmap_project/Vulnerability_Disclosure_Cheat_Sheet_ja.md
+++ b/skillmap_project/Vulnerability_Disclosure_Cheat_Sheet_ja.md
@@ -63,7 +63,7 @@ Googleの[Project Zero](https://googleprojectzero.blogspot.com/2020/01/policy-an
 
 以下のポイントでは、検討すべきいくつかの分野を紹介しています。
 
-* バグバウンティや類似のプログラムの下でテストを実施する場合、組織は[セーフハーバーポリシー](https://disclose.io)を確立している可能性があり、**プログラムの対象範囲と規則の範囲内であれば**、合法的にテストを実施することができます。対象範囲を注意深く読むようにしてください。対象範囲や規則を逸脱すると、犯罪行為となる可能性があります。
+* バグバウンティや類似のプログラムの下でテストを実施する場合、組織は[セーフハーバー・ポリシー](https://disclose.io)を確立している可能性があり、**プログラムの対象範囲と規則の範囲内であれば**、合法的にテストを実施することができます。対象範囲を注意深く読むようにしてください。対象範囲や規則を逸脱すると、犯罪行為となる可能性があります。
 * 国によってはリバースエンジニアリングを制限する法律があるため、ローカルにインストールされたソフトウェアに対するテストが許可されない場合があります。
 * セキュリティの脆弱性に関する情報を提供する条件として、あるいはその詳細を公表したり業界の規制当局に報告したりしないことと引き換えに、支払いやその他の報酬を要求してはいけません。
 * バグバウンティの支払いを受けた場合、これらは一般的に所得とみなされ、課税対象となる可能性があります。この収入を報告し、適切な税金を支払うことは、**受け取った側の**責任です。
@@ -75,8 +75,8 @@ Googleの[Project Zero](https://googleprojectzero.blogspot.com/2020/01/policy-an
 
 明確なディスクロージャーポリシーがない場合、以下の場所に連絡先がある場合があります。
 
-* [BugCrowd](https://bugcrowd.com/programs)、[HackerOne](https://hackerone.com/directory/programs)、[Open Bug Bounty](https://www.openbugbounty.org)などのバグバウンティプログラム
-* ウェブサイトの`/security.txt`または`/.well-known/security.txt`にある[security.txt](https://securitytxt.org)ファイル
+* [BugCrowd](https://bugcrowd.com/programs)、[HackerOne](https://hackerone.com/directory/programs)、[huntr.dev](https://huntr.dev/bounties)、[Open Bug Bounty](https://www.openbugbounty.org)、[Standoff](https://bugbounty.standoff365.com)などのバグバウンティプログラム
+* [RFC 9116](https://www.rfc-editor.org/rfc/rfc9116.html#name-location-of-the-securitytxt)に従い、ウェブサイトの`/.well-known/security.txt`に配置された[security.txt](https://securitytxt.org)ファイル
 * 既存のトラッキングシステム(issue tracking system)
 * `security@`または `abuse@` などのメールアドレス
 * ウェブサイトの一般的な「お問い合わせ」ページ
@@ -180,7 +180,7 @@ Googleの[Project Zero](https://googleprojectzero.blogspot.com/2020/01/policy-an
 * 報告に対応するための十分な時間とリソースがあること
 * 報告を効果的にトリアージするための十分なスキルを持ったスタッフがいること
     * レポートには大量の誤報が含まれている可能性があります
-    * 管理されたバグバウンティプログラムは、(コストをかけて)初期のトリアージを行うことで役立つかもしれません
+    * 管理されたバグバウンティプログラムは、（コストをかけて）初期のトリアージを行うことで役立つかもしれません
 * 大量の誤認識や無価値なレポートへの対応
 * 実稼働中のシステムを個人がテストすることによる影響（未熟な攻撃者が理解できない自動化ツールを実行することも含む）
 * 正当なテストトラフィックと悪意のある攻撃を区別できないこと
@@ -197,7 +197,7 @@ Googleの[Project Zero](https://googleprojectzero.blogspot.com/2020/01/policy-an
 * 「お問い合わせ」ページにセキュリティ専門の連絡先を設置
 * バグトラッカーでセキュリティ問題を報告するための専用の説明書
 * 一般的な `security@` のメールアドレス
-* [security.txt](https://securitytxt.org)ファイルを、ウェブサイトの`/security.txt`または`/.well-known/security.txt`に置く
+* [RFC 9116](https://www.rfc-editor.org/rfc/rfc9116.html#name-location-of-the-securitytxt)に従い、ウェブサイトの`/.well-known/security.txt`に[security.txt](https://securitytxt.org)ファイルを配置する
 * サードパーティのバグバウンティプログラムの利用
 
 また、窓口のスタッフ（メインの連絡先、ウェブチャット、電話回線を監視するスタッフなど）が、セキュリティ問題の報告をどのように処理するか、また、その報告を組織内の誰にエスカレーションすべきかを認識していることが重要です。
@@ -254,7 +254,7 @@ Googleの[Project Zero](https://googleprojectzero.blogspot.com/2020/01/policy-an
 * 脆弱性開示プロセスのタイムライン
 * 脆弱性を発見した研究者のクレジット
 * 脆弱性の技術的詳細
-* IDS/IPSのシグネチャやその他の侵害された痕跡
+* IDS/IPSのシグネチャやその他の侵害された痕跡(IoC)
 
 セキュリティアドバイザリは、開発者やシステム管理者が簡単に見つけられるようにする必要があります。一般的な公開方法には次のようなものがあります。
 
@@ -282,6 +282,6 @@ Googleの[Project Zero](https://googleprojectzero.blogspot.com/2020/01/policy-an
 参考文献
 -----
 
-* [The CERT Guide to Coordinated Vulnerability Disclosure（協調型脆弱性情報開示に関するCERTガイド](https://vuls.cert.org/confluence/display/CVD/The+CERT+Guide+to+Coordinated+Vulnerability+Disclosure)
+* [The CERT Guide to Coordinated Vulnerability Disclosure（協調型脆弱性情報開示に関するCERTガイド）](https://vuls.cert.org/confluence/display/CVD/The+CERT+Guide+to+Coordinated+Vulnerability+Disclosure)
 * [HackerOneの脆弱性開示ガイドライン](https://www.hackerone.com/disclosure-guidelines)
 * [Disclose.ioの脆弱性開示条件](https://github.com/disclose/dioterms)


### PR DESCRIPTION
[脆弱性情報開示のためのチートシート](https://github.com/OWASP/www-chapter-japan/blob/master/skillmap_project/Vulnerability_Disclosure_Cheat_Sheet_ja.md)に翻訳元の英語版の[Vulnerability Disclosure - OWASP Cheat Sheet Series](https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/Vulnerability_Disclosure_Cheat_Sheet.md)の更新を反映しました。